### PR TITLE
Vagrant Tweaks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,44 +63,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
     end
 
-    # define the dev machine
-    config.vm.define 'dev', autostart: false do |dev|
-
-        # define virtualbox dev machine
-        dev.vm.provider :virtualbox do |vb, override|
-
-            # sync this project folder to /cornerstone on the guest machine
-            override.vm.synced_folder '.', '/cornerstone', create: true
-
-            # sync this ./cache folder to /cache on the guest machine
-            override.vm.synced_folder 'cache', '/cache', create: true
-
-            # set the machine's image and network options
-            override.vm.box = 'ubuntu/trusty64'
-            override.vm.network :private_network, ip: '192.168.101.9'
-
-            # set the machine's memory and cpu utilization
-            vb.memory = 1024
-            vb.cpus = 2
-
-            # provision machine
-            override.vm.provision :shell, path: 'vagrant/install-jdk8_v1.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/bootstrap-dev-environment_v1.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/install-datastax-enterprise_v1.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/enable-spark.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/install-bower_v1.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/install-cornerstone.sh',
-                                          privileged: false
-            override.vm.provision :shell, path: 'vagrant/start-cornerstone.sh',
-                                          privileged: false
-        end
-    end
-
     # define MAX_DSE_NODES dse machines
     (0..MAX_DSE_NODES).each do |i|
         config.vm.define "dse#{i}" do |dse|
@@ -116,8 +78,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 override.vm.network :private_network, ip: "192.168.101.#{i+10}"
 
                 # set the machine's memory and cpu utilization
-                vb.memory = 3072
-                vb.cpus = 2
+                vb.memory = 2048
+                vb.cpus = 1
 
                 # install and start dse
                 override.vm.provision :shell,
@@ -188,6 +150,44 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                     end
                 end
             end
+        end
+    end
+
+    # define the dev machine
+    config.vm.define 'dev', autostart: true do |dev|
+
+        # define virtualbox dev machine
+        dev.vm.provider :virtualbox do |vb, override|
+
+            # sync this project folder to /cornerstone on the guest machine
+            override.vm.synced_folder '.', '/cornerstone', create: true
+
+            # sync this ./cache folder to /cache on the guest machine
+            override.vm.synced_folder 'cache', '/cache', create: true
+
+            # set the machine's image and network options
+            override.vm.box = 'ubuntu/trusty64'
+            override.vm.network :private_network, ip: '192.168.101.9'
+
+            # set the machine's memory and cpu utilization
+            vb.memory = 1024
+            vb.cpus = 1
+
+            # provision machine
+            override.vm.provision :shell, path: 'vagrant/install-jdk8_v1.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/bootstrap-dev-environment_v1.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/install-datastax-enterprise_v1.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/enable-spark.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/install-bower_v1.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/install-cornerstone.sh',
+                                          privileged: false
+            override.vm.provision :shell, path: 'vagrant/start-cornerstone.sh',
+                                          privileged: false
         end
     end
 

--- a/vagrant/install-cornerstone.sh
+++ b/vagrant/install-cornerstone.sh
@@ -27,8 +27,8 @@ if [ ! -f ${CFG} ]; then
     # generate new secret key and DSE IP addresses
     SECRET_KEY=$(openssl rand -base64 48)
 
-#    DSE_CLUSTER='192.168.101.10,192.168.101.11,192.168.101.12'
-    DSE_CLUSTER='127.0.0.1'
+    DSE_CLUSTER='192.168.101.10,192.168.101.11,192.168.101.12'
+    # DSE_CLUSTER='127.0.0.1'
 
     # make replacements
     sed -i -e "s/^SECRET_KEY.*/SECRET_KEY = '${SECRET_KEY}'/" ${CFG}

--- a/vagrant/install-datastax-enterprise_v1.sh
+++ b/vagrant/install-datastax-enterprise_v1.sh
@@ -23,8 +23,8 @@ if [ ! -d ${CACHE} ]; then
 fi
 sudo dpkg -i ${CACHE}/*
 
-sudo sed -i -e "s|^#MAX_HEAP_SIZE=.*|MAX_HEAP_SIZE=\"750M\"|g" /etc/dse/cassandra/cassandra-env.sh
-sudo sed -i -e "s|^#HEAP_NEWSIZE=.*|HEAP_NEWSIZE=\"200M\"|g" /etc/dse/cassandra/cassandra-env.sh
+# sudo sed -i -e "s|^#MAX_HEAP_SIZE=.*|MAX_HEAP_SIZE=\"750M\"|g" /etc/dse/cassandra/cassandra-env.sh
+# sudo sed -i -e "s|^#HEAP_NEWSIZE=.*|HEAP_NEWSIZE=\"200M\"|g" /etc/dse/cassandra/cassandra-env.sh
 
 if [ -n "${1}" ]; then
     sudo sed -i -e "s|listen_address:.*|listen_address: ${1}|g" /etc/dse/cassandra/cassandra.yaml

--- a/vagrant/start-cornerstone.sh
+++ b/vagrant/start-cornerstone.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/cornerstone/flask/run
+nohup /cornerstone/flask/run &


### PR DESCRIPTION
I have performed some slight tweaks to the Vagrantfile and some of the configuration scripts.

### ```Vagrantfile```
* Reduced # CPUs to 1
* Reduced RAM to 2GB
* Placed ```dev``` instance below dse nodes and set ```autostart: true```. When running ```vagrant up``` the dev instance will now come online after the dse nodes have bootstrapped

### ```install-cornerstone.sh```
* Updated configuration file to point at dse0-3 cluster

### ```install-datastax-enterprise_v1.sh```
* Commented out HEAP settings to use the defaults *(this may need to be changed)*

### ```start-cornerstone.sh```
* Started the flask process with nohup to place the process in the background. Without this vagrant would hang while flask runs in the foreground

